### PR TITLE
Initialize last_valid_reply with UTC timestamp 0

### DIFF
--- a/osdp/_device.py
+++ b/osdp/_device.py
@@ -17,7 +17,7 @@ class Device(object):
 
 		self._commands = queue.Queue()
 		self._secure_channel = SecureChannel()
-		self._last_valid_reply = datetime.datetime.now()
+		self._last_valid_reply = datetime.datetime.utcfromtimestamp(0)
 
 	@property
 	def is_security_established(self) -> bool:


### PR DESCRIPTION
The device's `last_valid_reply` was initialized with the timestamp of the object creation. This caused `device.is_online()` to return true at the start of the program, before a valid OSDP reply was actually received.